### PR TITLE
Fix blocking book widget

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -84,11 +84,11 @@
 .nav-list {
   display: flex;
   list-style-type: none;
-  overflow-x: scroll ;
+  overflow-x: auto;
   margin-block: 0 1em;
   padding: 0.25em 0;
   /*scrollbar-color: hsl(300deg 40% 35%) hsl(300deg 40% 90%);*/
-  scrollbar-color: transparent;
+  scrollbar-color: rgb(0 0 0 / 0) rgb(0 0 0 / 0);
   scrollbar-width: thin;
   white-space: nowrap;
   -webkit-overflow-scrolling: touch;
@@ -327,6 +327,15 @@
   margin-block: 2em;
   grid-column: 1 / 3;
   justify-self: center;
+}
+
+/* when AdBlocker is active */
+a[href^="https://partner.bol.com/click/"] + a.widget-alternative {
+  display: inline;
+}
+
+a:not([href^="https://partner.bol.com/click/"]) + a.widget-alternative {
+  display: none;
 }
 
 .widget img {

--- a/index.html
+++ b/index.html
@@ -356,6 +356,22 @@
             </div>
           </div>
         </a>
+        <a class="widget-alternative" href="https://www.bol.com/nl/nl/p/handboek-handboek-html5-en-css/9300000070553907/">
+          <div class="widget-container">
+            <div class="widget-image">
+              <picture>
+                <source srcset="/assets/images/9789463562645-groot.avif" type="image/avif">
+                <source srcset="/assets/images/9789463562645-groot.webp" type="image/webp">
+                <img src="/assets/images/9789463562645-300.jpg" alt="Omslag Handboek HTML 5 en CSS" width="300" height="402" loading="lazy">
+              </picture>
+            </div>
+            <div class="widget-text">
+              <p>
+                <span class="widget-text__title">Handboek HTML 5 en CSS<br>6e editie</span> <span>Peter Doolaard</span> <span>978-94-6356-264-5</span> <span>524 pagina's</span> <span>&euro; 44,99</span><span>Van Duuren Media, 2022</span>
+              </p>
+            </div>
+          </div>
+        </a>
       </aside>
     </main>
   </div>


### PR DESCRIPTION
AdBlock does what it has to do and blocks the book widget with the bol.com partner link. The fix duplicates the widget with a different/normal URL to the books product page on bol.com. A CSS-selector shows the alternative widget when the original one is blocked.   